### PR TITLE
global: bibdocfile dependency removal

### DIFF
--- a/invenio_previewer/utils.py
+++ b/invenio_previewer/utils.py
@@ -21,6 +21,8 @@
 
 import os
 
+import warnings
+
 from flask import url_for, current_app
 from flask_login import current_user
 
@@ -35,17 +37,15 @@ def get_pdf_path(f):
 
 def get_record_files(recid, filename):
     """Yield legacy BibDoc files."""
-    from invenio.legacy.bibdocfile.api import BibRecDocs
-    for f in BibRecDocs(recid).list_latest_files(list_hidden=False):
-        if f.name + f.superformat == filename or filename is None:
-            yield f
+    warnings.warn("get_record_files function has been deprecated",
+                  PendingDeprecationWarning)
+    return []
 
 
 def get_record_documents(recid, filename):
     """Yield LegacyBibDoc files from Documents."""
     from invenio_records.api import get_record
     from invenio_documents.api import Document
-    from invenio.legacy.bibdocfile.api import decompose_file
 
     record = get_record(recid)
     duuids = [uuid for (k, uuid) in record.get('_documents', [])
@@ -68,7 +68,9 @@ def get_record_documents(recid, filename):
         else:
             url = url_for('record.file', recid=recid, filename=filename)
 
-        (dummy, name, superformat) = decompose_file(filename)
+        basename = os.path.basename(filename)
+        (name, ext) = os.path.splitext(basename)
+        superformat = ext[1:]
 
         class LegacyBibDoc(object):
 

--- a/invenio_previewer/views.py
+++ b/invenio_previewer/views.py
@@ -22,7 +22,10 @@
 from __future__ import unicode_literals
 
 import itertools
+
 import os
+
+import warnings
 
 from flask import Blueprint, current_app, request
 
@@ -30,6 +33,7 @@ from flask_breadcrumbs import default_breadcrumb_root
 
 from invenio.base.globals import cfg
 from invenio.config import CFG_SITE_RECORD
+
 from invenio_records.views import request_record
 
 from .registry import previewers
@@ -78,7 +82,6 @@ def preview(recid):
 @request_record
 def get_pdf_maxpage(recid):
     """Get maximal page from pdf."""
-    from invenio.legacy.bibdocfile.api import BibRecDocs
-    from .previewerext.pdftk import maxpage
-
-    return maxpage(BibRecDocs(recid).list_latest_files(list_hidden=False)[0])
+    warnings.warn("get_pdf_maxpage endpoint has been deprecated",
+                  PendingDeprecationWarning)
+    return ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,13 +22,13 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-[wheel]
-universal=1
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build
 all_files = 1
+
+[bdist_wheel]
+universal = 1
 
 [compile_catalog]
 directory = invenio_previewer/translations/


### PR DESCRIPTION
* INCOMPATIBLE Removes dependency on legacy bibdocfile module.
  (addresses inveniosoftware/invenio#3233)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>