### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_previewer/previewerext/pdftk.py
+++ b/invenio_previewer/previewerext/pdftk.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,7 +21,7 @@
 
 from flask import abort, current_app, jsonify, request, safe_join
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.shell import run_shell_command  # FIXME: subprocess.Popen
 
 from ..tasks import generate_preview

--- a/invenio_previewer/tasks.py
+++ b/invenio_previewer/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,7 +23,7 @@ import os
 
 from flask import current_app, safe_join
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 from invenio.celery import celery
 from invenio.utils.shell import run_shell_command  # FIXME: subprocess.Popen

--- a/invenio_previewer/views.py
+++ b/invenio_previewer/views.py
@@ -31,7 +31,7 @@ from flask import Blueprint, current_app, request
 
 from flask_breadcrumbs import default_breadcrumb_root
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.config import CFG_SITE_RECORD
 
 from invenio_records.views import request_record

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,9 +21,7 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-documents.git#egg=invenio-documents
+-e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
     'invenio-documents>=0.1.0.post2',
     'invenio-records>=0.2.1',
 ]
@@ -49,6 +50,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>