### PR TITLE
global: addition of `previewable` template test

### DIFF
--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -233,11 +233,14 @@ need to write two methods and declare the entry point and the priority of your
 previewer.
 
 Let's try to create a ``.txt.`` file previewer. We need to provide two methods
-in a Python module: ``can_preview()`` and ``preview()``.
+in a Python module: ``can_preview()`` and ``preview()`` and also a variable
+specifying which extensions can preview: ``previewable_extensions`` .
 
 1. ``can_preview()`` is called in order to check if a given file can be
    previewed and should return a boolean.
 2. ``preview()`` is called to actually render the preview.
+3. ``previewable_extensions`` is a list of string saying which files extensions
+   can preview.
 
 Both methods is passed a ``PreviewFile`` instance, which contains the extract
 file dictionary, the record and the persistent identifier. ``PreviewFile`` also
@@ -246,6 +249,7 @@ Invenio-Files-REST.
 
 For our ``txt`` previewer, we can create a file with the following content:
 
+>>> def previewable_extensions = ['txt']
 >>> def can_preview(file):
 ...     return file.file['uri'].endswith('.txt')
 >>> def preview(file):

--- a/invenio_previewer/bundles.py
+++ b/invenio_previewer/bundles.py
@@ -94,7 +94,13 @@ zip_css = Bundle(
 """CSS bundle for ZIP file previewer."""
 
 zip_js = Bundle(
+    NpmBundle(
+        npm={
+            "bootstrap": "~3.3.6",
+        }
+    ),
     "js/zip/fullscreen.js",
+    "node_modules/bootstrap/dist/js/bootstrap.js",
     output='gen/zip.%(version)s.js',
 )
 """JavaScript bundle for ZIP file previewer."""

--- a/invenio_previewer/ext.py
+++ b/invenio_previewer/ext.py
@@ -40,6 +40,7 @@ class _InvenioPreviewerState(object):
         self.app = app
         self.entry_point_group = entry_point_group
         self.previewers = {}
+        self.previewable_extensions = set()
 
     def register_previewer(self, name, previewer):
         """Register a previewer in the system."""
@@ -47,6 +48,9 @@ class _InvenioPreviewerState(object):
             assert name not in self.previewers, \
                 "Previewer with same name already registered"
         self.previewers[name] = previewer
+        if hasattr(previewer, 'previewable_extensions'):
+            self.previewable_extensions |= set(
+                    previewer.previewable_extensions)
 
     def load_entry_point_group(self, entry_point_group):
         """Load previewers from an entry point group."""

--- a/invenio_previewer/extensions/csv_dthreejs.py
+++ b/invenio_previewer/extensions/csv_dthreejs.py
@@ -32,6 +32,9 @@ from chardet.universaldetector import UniversalDetector
 from flask import current_app, render_template
 
 
+previewable_extensions = ['csv', 'dsv']
+
+
 def validate_csv(file):
     """Return dialect information about given csv file."""
     # Read first X bytes from file.

--- a/invenio_previewer/extensions/default.py
+++ b/invenio_previewer/extensions/default.py
@@ -28,6 +28,8 @@ from __future__ import absolute_import, print_function
 
 from flask import render_template
 
+previewable_extensions = []
+
 
 def can_preview(file):
     """Return if file type can be previewed."""

--- a/invenio_previewer/extensions/mistune.py
+++ b/invenio_previewer/extensions/mistune.py
@@ -31,6 +31,9 @@ from flask import render_template
 import mistune
 
 
+previewable_extensions = ['md']
+
+
 def render(file):
     """Render HTML from Markdown file content."""
     fp = file.open()

--- a/invenio_previewer/extensions/pdfjs.py
+++ b/invenio_previewer/extensions/pdfjs.py
@@ -29,6 +29,9 @@ from __future__ import absolute_import, print_function
 from flask import render_template
 
 
+previewable_extensions = ['pdf', 'pdfa']
+
+
 def can_preview(file):
     """Check if file can be previewed."""
     return file.has_extensions('.pdf', '.pdfa')

--- a/invenio_previewer/extensions/zip.py
+++ b/invenio_previewer/extensions/zip.py
@@ -32,6 +32,9 @@ import zipfile
 from flask import current_app, render_template
 
 
+previewable_extensions = ['zip']
+
+
 def make_tree(file):
     """Create tree structure from ZIP archive."""
     max_files_count = current_app.config.get('PREVIEWER_ZIP_MAX_FILES', 1000)

--- a/invenio_previewer/templates/invenio_previewer/default.html
+++ b/invenio_previewer/templates/invenio_previewer/default.html
@@ -30,7 +30,7 @@
 {% block panel %}
 <div class="container">
     <div class="col-md-2 col-md-offset-3">
-        <h3><i class="glyphicon glyphicon-remove"></i> {{_('Cannot preview file')}}</h3>
+        <h3><i class="fa fa-remove"></i> {{_('Cannot preview file')}}</h3>
         <p>{{_('Sorry, we are unfortunately not able to preview this file.')}}</p>
     </div>
 </div>

--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -340,8 +340,9 @@
 
     {% assets "pdfjs_css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
     {% assets "pdfjs_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+    {% assets "invenio_theme_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
     <script>
-      PDFView.open('{{ file.uri }}');
+      PDFView.open('{{ url_for('invenio_files_rest.object_api', bucket_id=file.bucket, key=file.filename) }}');
     </script>
   </body>
 </html>

--- a/invenio_previewer/templates/invenio_previewer/zip.html
+++ b/invenio_previewer/templates/invenio_previewer/zip.html
@@ -95,5 +95,6 @@
     </ul>
   </div>
 </div> <!-- panel panel-default close -->
+{% assets "invenio_theme_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
 {% assets "zip_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
 {% endblock %}

--- a/invenio_previewer/views.py
+++ b/invenio_previewer/views.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import, print_function
 from os.path import splitext
 
 import pkg_resources
-from flask import Blueprint, abort, request
+from flask import Blueprint, abort, current_app, request
 
 from .extensions import default
 from .proxies import current_previewer
@@ -128,3 +128,11 @@ def preview(pid, record, template=None):
         if plugin.can_preview(file):
             return plugin.preview(file)
     return default.preview(file)
+
+
+@blueprint.app_template_test('previewable')
+def is_previewable(file):
+    """Test if a file can be previewed checking its extension."""
+    previewable_extensions = current_app.extensions[
+        'invenio-previewer'].previewable_extensions
+    return file['type'] in previewable_extensions

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,3 +58,22 @@ def test_view_macro_file_list(app):
         assert 'href="http://otherdomain/test2.txt"' in result
         assert '<td class="nowrap">2016-07-12</td>' in result
         assert '<td class="nowrap">12</td>' in result
+
+
+def test_previwable_test(app):
+    """Test template test."""
+    file = {
+        'type': 'md'
+    }
+    template = "{% if file is previewable %}Previwable" \
+               "{% else %}Not previwable{% endif %}"
+    assert render_template_string(template, file=file) == "Previwable"
+
+    file['type'] = 'no'
+    assert render_template_string(template, file=file) == "Not previwable"
+
+    file['type'] = 'pdf'
+    assert render_template_string(template, file=file) == "Previwable"
+
+    file['type'] = ''
+    assert render_template_string(template, file=file) == "Not previwable"


### PR DESCRIPTION
* Adds a new template test to check if there is an extension that can preview a file.

* Fixes PDFJS and ZIP issues adding the proper javascript.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>