### PR TITLE
extensions: image previewer

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -75,6 +75,13 @@ PDF (pdf.js)
    :members:
    :undoc-members:
 
+Simple Images
+~~~~~~~~~~~~~
+
+.. automodule:: invenio_previewer.extensions.simple_image
+   :members:
+   :undoc-members:
+
 XML (prism.js)
 ~~~~~~~~~~~~~~
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -94,7 +94,7 @@ example data:
 
 10. Open a web browser and enter to the url
 `http://localhost:5000/records/RECORD_PID/preview` where
-`RECORD_ID` is a number between 1 and 5.
+`RECORD_ID` is a number between 1 and 10.
 
 
 11. Open now a record that contains several files (The last record created).
@@ -164,7 +164,7 @@ def fixtures():
 
 def create_object(bucket, file_name, stream):
     """Object creation inside the bucket using the file and its content."""
-    ObjectVersion.create(bucket, file_name, stream=stream)
+    obj = ObjectVersion.create(bucket, file_name, stream=stream)
     rec_uuid = uuid4()
     provider = RecordIdProvider.create(object_type='rec', object_uuid=rec_uuid)
     data = {
@@ -173,6 +173,8 @@ def create_object(bucket, file_name, stream):
             {
                 'uri': '/files/{0}/{1}'.format(str(bucket.id), file_name),
                 'key': file_name,
+                'filename': file_name,
+                'size': obj.file.size,
                 'bucket': str(bucket.id),
                 'local': True
             }
@@ -193,32 +195,24 @@ def files():
     # Bucket
     bucket = Bucket.create(loc)
 
-    # Markdown file
-    markdown_file = 'markdown.md'
-    with open(os.path.join(data_path, markdown_file), 'rb') as fp:
-        create_object(bucket, markdown_file, fp)
+    # Example files from the data folder
+    example_files = (
+        'markdown.md',
+        'csvfile.csv',
+        'zipfile.zip',
+        'jsonfile.json',
+        'xmlfile.xml',
+        'notebook.ipynb',
+        'jpgfile.jpg',
+        'pngfile.png',
+    )
 
-    # CSV file
-    csv_file = 'csvfile.csv'
-    with open(os.path.join(data_path, csv_file), 'rb') as fp:
-        create_object(bucket, csv_file, fp)
+    # Create single file records
+    for f in example_files:
+        with open(os.path.join(data_path, f), 'rb') as fp:
+            create_object(bucket, f, fp)
 
-    # PDF file
-    pdf_file = 'pdffile.pdf'
-    with open(os.path.join(data_path, pdf_file), 'rb') as fp:
-        create_object(bucket, pdf_file, fp)
-
-    # ZIP file
-    zip_file = 'zipfile.zip'
-    with open(os.path.join(data_path, zip_file), 'rb') as fp:
-        create_object(bucket, zip_file, fp)
-
-    # IPYNB file
-    ipynb_file = 'notebook.ipynb'
-    with open(os.path.join(data_path, ipynb_file), 'rb') as fp:
-        create_object(bucket, ipynb_file, fp)
-
-    # Multiple files
+    # Create a multi-file record
     rec_uuid = uuid4()
     provider = RecordIdProvider.create(object_type='rec', object_uuid=rec_uuid)
     data = {
@@ -230,30 +224,17 @@ def files():
     template_file = {
         'uri': '/files/{0}/{1}',
         'key': '',
+        'filename': '',
         'bucket': str(bucket.id),
         'local': True
     }
 
-    # Creation of markdown file dictionary
-    markdown_file_data = template_file.copy()
-    markdown_file_data['uri'] = markdown_file_data['uri'].format(
-            str(bucket.id), markdown_file)
-    markdown_file_data['key'] = markdown_file
-    data['files'].append(markdown_file_data)
-
-    # Creation of csv file dictionary
-    csv_file_data = template_file.copy()
-    csv_file_data['uri'] = csv_file_data['uri'].format(
-            str(bucket.id), csv_file)
-    csv_file_data['key'] = csv_file
-    data['files'].append(csv_file_data)
-
-    # Creation of pdf file dictionary
-    pdf_file_data = template_file.copy()
-    pdf_file_data['uri'] = pdf_file_data['uri'].format(
-            str(bucket.id), pdf_file)
-    pdf_file_data['key'] = pdf_file
-    data['files'].append(pdf_file_data)
+    for filename in example_files:
+        file_data = template_file.copy()
+        file_data['uri'] = file_data['uri'].format(str(bucket.id), filename)
+        file_data['key'] = filename
+        file_data['filename'] = filename
+        data['files'].append(file_data)
 
     Record.create(data, id_=rec_uuid)
 

--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -33,6 +33,7 @@ module comes with viewers for the following files types:
 - CSV (using d3.js)
 - Markdown (using Mistune library)
 - XML and JSON (using Prism.js)
+- Simple images (PNG, JPG, GIF)
 
 Invenio-Previewer only provides the front-end layer for displaying previews
 of files. Specifically Invenio-Previewer does not take care of generating
@@ -207,6 +208,10 @@ This module contains several previewers out-of-the-box:
 
 - ``PDF`` - Previews a PDF file in your browser using `PDF.JS` library.
 
+- ``Simple Images``: Previews simple images. Supported formats are JPG, PNG
+  and GIF. There is also a configurable file size limit, which by default is
+  set to 512KB.
+
 - ``ZIP`` - Previews file tree inside the archive. You can specify a files
   limit to avoid a temporary lock in both of client and server side when you
   are dealing with large ZIP files. By default, this limit is set 1000 files.
@@ -220,7 +225,7 @@ Local vs. remote files
 Some of the bundled previewers are only working with locally managed  files
 (i.e. files stored in Invenio-Files-REST, which supports many different storage
 backends). This is the case for JSON, XML, CSV, Markdown and ZIP previewers.
-The PDF previewer doesn't need have the files stored locally.
+The PDF and Image previewer doesn't need to have the files stored locally.
 
 Override default previewer
 --------------------------
@@ -282,6 +287,7 @@ is going to be perfect in the case of this TXT previewer:
 >>>         'invenio_previewer.extensions.csv_dthreejs',
 >>>         'invenio_previewer.extensions.json_prismjs',
 >>>         'invenio_previewer.extensions.xml_prismjs',
+>>>         'invenio_previewer.extensions.simple_image',
 >>>         'invenio_previewer.extensions.mistune',
 >>>         'invenio_previewer.extensions.pdfjs',
 >>>         'invenio_previewer.extensions.zip',

--- a/invenio_previewer/config.py
+++ b/invenio_previewer/config.py
@@ -30,11 +30,15 @@ PREVIEWER_CSV_VALIDATION_BYTES = 1024
 PREVIEWER_MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024
 """Maximum file size in bytes for JSON/XML files."""
 
+PREVIEWER_MAX_IMAGE_SIZE_BYTES = 0.5 * 1024 * 1024
+"""Maximum file size in bytes for image files."""
+
 PREVIEWER_ZIP_MAX_FILES = 1000
 """Max number of files showed in the ZIP previewer."""
 
 PREVIEWER_PREFERENCE = [
     'csv_dthreejs',
+    'simple_image',
     'json_prismjs',
     'xml_prismjs',
     'mistune',

--- a/invenio_previewer/extensions/simple_image.py
+++ b/invenio_previewer/extensions/simple_image.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Previews simple image files."""
+
+from __future__ import absolute_import, print_function
+
+from flask import current_app, render_template, url_for
+
+previewable_extensions = ['jpg', 'jpeg', 'png', 'gif']
+
+
+def validate(file):
+    """Validate a simple image file."""
+    max_file_size = current_app.config.get(
+        'PREVIEWER_MAX_IMAGE_SIZE_BYTES', 0.5 * 1024 * 1024)
+    return 'size' in file.file and file.file['size'] <= max_file_size
+
+
+def can_preview(file):
+    """Determine if the given file can be previewed."""
+    supported_extensions = ('.jpg', '.jpeg', '.png', '.gif')
+    return file.has_extensions(*supported_extensions) and validate(file)
+
+
+def preview(file):
+    """Render appropiate template with embed flag."""
+    return render_template(
+        'invenio_previewer/simple_image.html',
+        file=file.file,
+        file_url=url_for(
+            'invenio_files_rest.object_api',
+            bucket_id=file.file['bucket'],
+            key=file.file['filename'])
+    )

--- a/invenio_previewer/templates/invenio_previewer/simple_image.html
+++ b/invenio_previewer/templates/invenio_previewer/simple_image.html
@@ -1,0 +1,30 @@
+{# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+#}
+
+{%- extends config.PREVIEWER_ABSTRACT_TEMPLATE %}
+
+{% block panel %}
+<img src="{{ file_url }}" style="max-width: 100%;">
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -151,12 +151,13 @@ setup(
             '= invenio_previewer.bundles:fullscreen_js',
             'previewer_prism_js '
             '= invenio_previewer.bundles:prism_js',
-            'previewer_prism_css = '
-            'invenio_previewer.bundles:prism_css',
+            'previewer_prism_css '
+            '= invenio_previewer.bundles:prism_css',
         ],
         'invenio_previewer.previewers': [
             'csv_dthreejs = invenio_previewer.extensions.csv_dthreejs',
             'json_prismjs = invenio_previewer.extensions.json_prismjs',
+            'simple_image = invenio_previewer.extensions.simple_image',
             'xml_prismjs = invenio_previewer.extensions.xml_prismjs',
             'mistune = invenio_previewer.extensions.mistune',
             'pdfjs = invenio_previewer.extensions.pdfjs',

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -199,6 +199,17 @@ def test_ipynb_extension(app, webassets, bucket, record):
         assert 'This is an example notebook.' in res.get_data(as_text=True)
 
 
+def test_simple_image_extension(app, webassets, bucket, record):
+    """Test view with simple image files (PNG)."""
+    create_file(
+        record, bucket, 'test.png', BytesIO(b'Content not used'))
+
+    with app.test_client() as client:
+        res = client.get(preview_url(record['recid'], 'test.png'))
+        assert '<img src="' in res.get_data(as_text=True)
+        assert 'style="max-width: 100%;">' in res.get_data(as_text=True)
+
+
 def test_no_local_file(app, webassets, bucket, record):
     """Test a not local file which can not be previewed."""
     filename = 'default'


### PR DESCRIPTION
* Adds support for small (<500KB) and simple images (JPG, PNG, GIF). (closes #22)

* Reorganizes examples to make extension additions easier.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>