### PR TITLE
global: record file factory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@
 Changes
 =======
 
-Version 1.0.0a3 (release 2016-05-11)
+Version 1.0.0a4 (release 2016-05-23)
 ------------------------------------
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ============================
- Invenio-Previewer v1.0.0a3
+ Invenio-Previewer v1.0.0a4
 ============================
 
-Invenio-Previewer v1.0.0a3 was released on May 11, 2016.
+Invenio-Previewer v1.0.0a4 was released on May 23, 2016.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-previewer==1.0.0a3
+   $ pip install invenio-previewer==1.0.0a4
 
 Documentation
 -------------

--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -68,6 +68,7 @@ view function set to ``invenio_previewer.views:preview``:
 ...             pid_type='recid',
 ...             route='/records/<pid_value>/preview/<filename>',
 ...             view_imp='invenio_previewer.views:preview',
+...             record_class='invenio_records_files.api:Record',
 ...         ),
 ...     )
 ... )
@@ -151,19 +152,12 @@ Next, let's create a persistent identifier:
 
 Let's create the record with the file information:
 
->>> from invenio_records import Record
+>>> from invenio_records_files.api import Record, RecordsBuckets
 >>> data = {
 ...     'control_number': provider.pid.pid_value,
-...     'files': [
-...         {
-...             'key': obj.key,
-...             'bucket': str(bucket.id),
-...             'checksum': obj.file.checksum,
-...             'size': obj.file.size,
-...         }
-...     ]
 ... }
 >>> record = Record.create(data, id_=rec_uuid)
+>>> record.model.records_buckets = RecordsBuckets(bucket=bucket)
 >>> db.session.commit()
 
 Previewing file
@@ -310,6 +304,7 @@ bundle. Check ``Invenio-Assets`` out to learn how to add them.
 from __future__ import absolute_import, print_function
 
 from .ext import InvenioPreviewer
+from .proxies import current_previewer
 from .version import __version__
 
-__all__ = ('__version__', 'InvenioPreviewer')
+__all__ = ('__version__', 'current_previewer', 'InvenioPreviewer')

--- a/invenio_previewer/api.py
+++ b/invenio_previewer/api.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""File reader utility."""
+
+from __future__ import absolute_import, print_function
+
+from os.path import basename, splitext
+
+from flask import url_for
+
+
+class PreviewFile(object):
+    """Preview file default implementation."""
+
+    def __init__(self, pid, record, fileobj):
+        """Default constructor.
+
+        :param file: ObjectVersion instance from Invenio-Files-REST.
+        """
+        self.file = fileobj
+        self.pid = pid
+        self.record = record
+
+    @property
+    def size(self):
+        """Get file size."""
+        return self.file['size']
+
+    @property
+    def filename(self):
+        """Get filename."""
+        return basename(self.file.key)
+
+    @property
+    def bucket(self):
+        """Get bucket."""
+        return self.file.bucket_id
+
+    @property
+    def uri(self):
+        """Get file download link.
+
+        ..  note::
+
+            The URI generation assumes that you can download the file using the
+            view ``invenio_records_ui.<pid_type>_files``.
+        """
+        return url_for(
+            '.{0}_files'.format(self.pid.pid_type),
+            pid_value=self.pid.pid_value,
+            filename=self.file.key)
+
+    def is_local(self):
+        """Check if file is local."""
+        return True
+
+    def has_extensions(self, *exts):
+        """Check if file has one of the extensions."""
+        file_ext = splitext(self.filename)[1]
+        file_ext = file_ext.lower()
+
+        for e in exts:
+            if file_ext == e:
+                return True
+        return False
+
+    def open(self):
+        """Open the file."""
+        return self.file.file.storage().open()

--- a/invenio_previewer/config.py
+++ b/invenio_previewer/config.py
@@ -55,3 +55,6 @@ PREVIEWER_BASE_CSS_BUNDLES = ['invenio_theme_css']
 
 PREVIEWER_BASE_JS_BUNDLES = ['invenio_theme_js']
 """Basic bundle which includes Bootstrap/jQuery."""
+
+PREVIEWER_RECORD_FILE_FACOTRY = None
+"""Factory for extracting files from records."""

--- a/invenio_previewer/extensions/csv_dthreejs.py
+++ b/invenio_previewer/extensions/csv_dthreejs.py
@@ -53,7 +53,7 @@ def validate_csv(file):
         dialect = csv.Sniffer().sniff(content)
     except Exception as e:
         current_app.logger.debug(
-            'File {0} is not valid CSV: {1}'.format(file.file['uri'], e))
+            'File {0} is not valid CSV: {1}'.format(file.uri, e))
         return {
             'delimiter': '',
             'encoding': '',
@@ -94,7 +94,7 @@ def preview(file):
     file_info = validate_csv(file)
     return render_template(
         'invenio_previewer/csv_bar.html',
-        file=file.file,
+        file=file,
         delimiter=file_info['delimiter'],
         encoding=file_info['encoding'],
         js_bundles=current_previewer.js_bundles + ['previewer_zip_js'],

--- a/invenio_previewer/extensions/default.py
+++ b/invenio_previewer/extensions/default.py
@@ -38,4 +38,4 @@ def can_preview(file):
 
 def preview(file):
     """Return appropriate template and passes the file and an embed flag."""
-    return render_template("invenio_previewer/default.html", f=file.file)
+    return render_template("invenio_previewer/default.html", file=file)

--- a/invenio_previewer/extensions/ipynb.py
+++ b/invenio_previewer/extensions/ipynb.py
@@ -27,10 +27,8 @@
 from __future__ import absolute_import, unicode_literals
 
 import nbformat
-
-from nbconvert import HTMLExporter
-
 from flask import render_template
+from nbconvert import HTMLExporter
 
 
 def render(file):
@@ -56,7 +54,9 @@ def preview(file):
     """Render the IPython Notebook."""
     body, resources = render(file)
     default_ipython_style = resources['inlining']['css'][1]
-    return render_template('invenio_previewer/ipynb.html',
-                           file=file.file,
-                           content=body,
-                           style=default_ipython_style)
+    return render_template(
+        'invenio_previewer/ipynb.html',
+        file=file,
+        content=body,
+        style=default_ipython_style
+    )

--- a/invenio_previewer/extensions/json_prismjs.py
+++ b/invenio_previewer/extensions/json_prismjs.py
@@ -46,7 +46,7 @@ def validate_json(file):
     """Validate a JSON file."""
     max_file_size = current_app.config.get(
         'PREVIEWER_MAX_FILE_SIZE_BYTES', 1 * 1024 * 1024)
-    if 'size' in file.file and file.file['size'] > max_file_size:
+    if file.size > max_file_size:
         return False
 
     with file.open() as fp:
@@ -68,7 +68,7 @@ def preview(file):
     """Render appropiate template with embed flag."""
     return render_template(
         'invenio_previewer/json_prismjs.html',
-        file=file.file,
+        file=file,
         content=render(file),
         js_bundles=['previewer_prism_js'],
         css_bundles=['previewer_prism_css'],

--- a/invenio_previewer/extensions/mistune.py
+++ b/invenio_previewer/extensions/mistune.py
@@ -51,5 +51,5 @@ def can_preview(file):
 def preview(file):
     """Render Markdown."""
     return render_template("invenio_previewer/mistune.html",
-                           file=file.file,
+                           file=file,
                            content=render(file))

--- a/invenio_previewer/extensions/pdfjs.py
+++ b/invenio_previewer/extensions/pdfjs.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import render_template, url_for
+from flask import render_template
 
 from ..proxies import current_previewer
 
@@ -42,12 +42,10 @@ def preview(file):
     """Preview file."""
     return render_template(
         'invenio_previewer/pdfjs.html',
-        file=file.file,
+        file=file,
         css_bundles=['previewer_pdfjs_css'],
-        js_bundles=['previewer_pdfjs_js',  'previewer_fullscreen_js'
-                    ] + current_previewer.js_bundles,
-        file_url=url_for(
-            'invenio_files_rest.object_api',
-            bucket_id=file.file['bucket'],
-            key=file.file['key'])
+        js_bundles=[
+            'previewer_pdfjs_js',
+            'previewer_fullscreen_js'
+        ] + current_previewer.js_bundles,
     )

--- a/invenio_previewer/extensions/xml_prismjs.py
+++ b/invenio_previewer/extensions/xml_prismjs.py
@@ -45,7 +45,7 @@ def validate_xml(file):
     """Validate an XML file."""
     max_file_size = current_app.config.get(
         'PREVIEWER_MAX_FILE_SIZE_BYTES', 1 * 1024 * 1024)
-    if 'size' in file.file and file.file['size'] > max_file_size:
+    if file.size > max_file_size:
         return False
 
     with file.open() as fp:
@@ -68,7 +68,7 @@ def preview(file):
     """Render appropiate template with embed flag."""
     return render_template(
         'invenio_previewer/xml_prismjs.html',
-        file=file.file,
+        file=file,
         content=render(file),
         js_bundles=['previewer_prism_js'],
         css_bundles=['previewer_prism_css'],

--- a/invenio_previewer/extensions/zip.py
+++ b/invenio_previewer/extensions/zip.py
@@ -89,7 +89,7 @@ def preview(file):
     list = children_to_list(tree)['children']
     return render_template(
         "invenio_previewer/zip.html",
-        file=file.file,
+        file=file,
         tree=list,
         limit_reached=limit_reached,
         js_bundles=current_previewer.js_bundles + ['previewer_fullscreen_js'],

--- a/invenio_previewer/templates/invenio_previewer/bottom.html
+++ b/invenio_previewer/templates/invenio_previewer/bottom.html
@@ -85,7 +85,7 @@
 # based on embed flag #}
 <div id="bottom">
   <div class="container row">
-    <div class="span5 offset1"><h3>{{_('Previewing')}}: {{ file.key }}</h3></div>
+    <div class="span5 offset1"><h3>{{_('Previewing')}}: {{ file.filename }}</h3></div>
     <div class="span3">
       <a role="button" class="btn btn-inverse" data-toggle="modal" href="#embedModal">{{_('Embed')}}&nbsp;&nbsp<i class="icon-share icon-white"></i></a>
       <a role="button" class="btn btn-inverse" href="{{ file.uri }}">{{_('Download')}}&nbsp;&nbsp<i class="icon-download icon-white"></i></a>

--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -327,7 +327,7 @@
       {%- endassets %}
     {%- endfor %}
     <script>
-      PDFViewerApplication.open('{{ url_for('invenio_files_rest.object_api', bucket_id=file.bucket, key=file.key) }}');
+      PDFViewerApplication.open('{{ file.uri }}');
     </script>
   </body>
 </html>

--- a/invenio_previewer/templates/invenio_previewer/simple_image.html
+++ b/invenio_previewer/templates/invenio_previewer/simple_image.html
@@ -26,5 +26,5 @@
 {%- extends config.PREVIEWER_ABSTRACT_TEMPLATE %}
 
 {% block panel %}
-<img src="{{ file_url }}" style="max-width: 100%;">
+<img src="{{ file.uri }}" style="max-width: 100%;">
 {% endblock %}

--- a/invenio_previewer/templates/invenio_previewer/top.html
+++ b/invenio_previewer/templates/invenio_previewer/top.html
@@ -44,7 +44,7 @@
 <div id="top">
   <div class="container row">
     <div class="span8 offset1">
-      <h2>{{ file.key }}</h2>
+      <h2>{{ file.filename }}</h2>
     </div>
   </div>
 </div>

--- a/invenio_previewer/templates/invenio_previewer/zip.html
+++ b/invenio_previewer/templates/invenio_previewer/zip.html
@@ -58,7 +58,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <div class="panel-title">
-      <i class="fa fa-file-zip-o"></i> {{ file.key }}
+      <i class="fa fa-file-zip-o"></i> {{ file.filename }}
       <div id="fullScreenMode" title="{{ _('Full screen') }}" class="pull-right"><i class="fa fa-fw fa-arrows-alt"></i></div>
     </div>
   </div>

--- a/invenio_previewer/version.py
+++ b/invenio_previewer/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a4.dev20160511"
+__version__ = "1.0.0a4"

--- a/invenio_previewer/views.py
+++ b/invenio_previewer/views.py
@@ -26,20 +26,11 @@
 
 from __future__ import absolute_import, print_function
 
-from os.path import splitext
-
-import pkg_resources
 from flask import Blueprint, abort, request
 
+from .api import PreviewFile
 from .extensions import default
 from .proxies import current_previewer
-
-try:
-    pkg_resources.get_distribution('invenio-files-rest')
-    HAS_FILES_REST = True
-except pkg_resources.DistributionNotFound:
-    HAS_FILES_REST = False
-
 
 blueprint = Blueprint(
     'invenio_previewer',
@@ -48,50 +39,6 @@ blueprint = Blueprint(
     static_folder='static',
 )
 """Blueprint used to register template and static folders."""
-
-
-class PreviewFile(object):
-    """Preview file default implementation."""
-
-    def __init__(self, file, pid, record):
-        """Default constructor."""
-        self.file = file
-        self.pid = pid
-        self.record = record
-
-    def is_local(self):
-        """Check if file is local."""
-        return 'bucket' in self.file
-
-    def has_extensions(self, *exts):
-        """Check if file has one of the extensions."""
-        file_ext = splitext(self.file['key'])[1]
-        file_ext = file_ext.lower()
-
-        for e in exts:
-            if file_ext == e:
-                return True
-        return False
-
-    def open(self):
-        """Open the file."""
-        if not HAS_FILES_REST:
-            raise RuntimeError(
-                "Invenio-Files-REST must be installed for open to work.")
-
-        from invenio_files_rest.models import ObjectVersion
-        assert 'bucket' in self.file
-        assert 'key' in self.file
-
-        obj = ObjectVersion.get(self.file['bucket'], self.file['key'])
-        return obj.file.storage().open()
-
-
-def get_file(pid, record, filename=None):
-    """Return the PreviewFile associated with the record."""
-    for f in record['files']:
-        if filename and f['key'] == filename:
-            return PreviewFile(f, pid, record)
 
 
 def preview(pid, record, template=None):
@@ -106,28 +53,32 @@ def preview(pid, record, template=None):
                 # ...
                 route='/records/<pid_value/preview',
                 view_imp='invenio_previewer.views.preview',
+                record_class='invenio_records_files.api:Record',
             )
         )
     """
-    filename = request.view_args.get(
-        'filename',
-        request.args.get('filename', type=str)
+    # Get file from record
+    fileobj = current_previewer.record_file_factory(
+        pid, record, request.view_args.get(
+            'filename', request.args.get('filename', type=str))
     )
-
-    file = get_file(
-        pid, record, filename=filename)
-
-    if file is None:
+    if not fileobj:
         abort(404)
 
-    file_previewer = file.file.get('previewer')
-    previewers = current_previewer.iter_previewers(
-        previewers=[file_previewer] if file_previewer else None)
+    # Try to see if specific previewer is requested?
+    try:
+        file_previewer = fileobj['previewer']
+    except KeyError:
+        file_previewer = None
 
-    for plugin in previewers:
-        if plugin.can_preview(file):
-            return plugin.preview(file)
-    return default.preview(file)
+    # Find a suitable previewer
+    fileobj = PreviewFile(pid, record, fileobj)
+    for plugin in current_previewer.iter_previewers(
+            previewers=[file_previewer] if file_previewer else None):
+        if plugin.can_preview(fileobj):
+            return plugin.preview(fileobj)
+
+    return default.preview(fileobj)
 
 
 @blueprint.app_template_test('previewable')

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
-    'invenio-db>=1.0.0a9',
+    'invenio-db[versioning]>=1.0.0a9',
+    'invenio-records-files>=1.0.0a3',
     'isort>=4.2.2',
     'mock>=1.3.0',
     'pydocstyle>=1.0.0',
@@ -51,7 +52,8 @@ extras_require = {
         'Sphinx>=1.3',
     ],
     'files': [
-        'invenio-files-rest>=1.0.0.dev20150000',
+        'invenio-files-rest>=1.0.0a1',
+        'invenio-records-files>=1.0.0a2',
     ],
     'tests': tests_require,
 }

--- a/tests/test_invenio_previewer.py
+++ b/tests/test_invenio_previewer.py
@@ -50,11 +50,11 @@ def _mock_entry_points(group=None):
             MockEntryPoint(
                 'default',
                 'invenio_previewer.extensions.default',
-                ),
+            ),
             MockEntryPoint(
                 'zip',
                 'invenio_previewer.extensions.zip',
-                ),
+            ),
         ],
     }
     names = data.keys() if group is None else [group]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,32 +22,15 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Previews simple image files."""
+"""Test of utilities module."""
 
 from __future__ import absolute_import, print_function
 
-from flask import current_app, render_template
-
-previewable_extensions = ['jpg', 'jpeg', 'png', 'gif']
+from invenio_previewer import current_previewer
 
 
-def validate(file):
-    """Validate a simple image file."""
-    max_file_size = current_app.config.get(
-        'PREVIEWER_MAX_IMAGE_SIZE_BYTES', 0.5 * 1024 * 1024)
-    return file.size <= max_file_size
-
-
-def can_preview(file):
-    """Determine if the given file can be previewed."""
-    supported_extensions = ('.jpg', '.jpeg', '.png', '.gif')
-    return file.has_extensions(*supported_extensions) and validate(file)
-
-
-def preview(file):
-    """Render appropiate template with embed flag."""
-    return render_template(
-        'invenio_previewer/simple_image.html',
-        file=file,
-        file_url=file.uri
-    )
+def test_default_file_reader(app, record_with_file, testfile):
+    """Test view by default."""
+    file_ = current_previewer.record_file_factory(
+        None, record_with_file, testfile.key)
+    assert file_.version_id == testfile.version_id


### PR DESCRIPTION
* INCOMPATIBLE Changes record file factory for extracting files from
  records. Files must reside in _files and you must specify the
  Record class from Invenio-Records-Files.

* Refactors the PreviewFile API.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>