### PR TITLE
csv: handling of unparsable unicode

### DIFF
--- a/invenio_previewer/templates/invenio_previewer/zip.html
+++ b/invenio_previewer/templates/invenio_previewer/zip.html
@@ -56,16 +56,24 @@
 
 {%- block panel %}
 <div class="panel panel-default">
-  <div class="panel-heading">
-    <div class="panel-title">
-      <i class="fa fa-file-zip-o"></i> {{ file.filename }}
-      <div id="fullScreenMode" title="{{ _('Full screen') }}" class="pull-right"><i class="fa fa-fw fa-arrows-alt"></i></div>
-    </div>
-  </div>
-  {% if- limit_reached %}
+{% if error %}
   <div class="panel-heading panel-heading-alert">
     <div class="panel-title">
-      <i class="fa fa-exclamation"></i>
+      <i class="fa fa-fw fa-exclamation"></i>
+      {{ _(error) }}
+    </div>
+  </div>
+{% else %}
+<div class="panel-heading">
+  <div class="panel-title">
+    <i class="fa fa-file-zip-o"></i> {{ file.filename }}
+    <div id="fullScreenMode" title="{{ _('Full screen') }}" class="pull-right"><i class="fa fa-fw fa-arrows-alt"></i></div>
+  </div>
+</div>
+  {%- if limit_reached %}
+  <div class="panel-heading panel-heading-alert">
+    <div class="panel-title">
+      <i class="fa fa-fw fa-exclamation"></i>
       {{ _('The previewer is not showing all the files') }}
     </div>
   </div>
@@ -91,5 +99,6 @@
       {%- endfor %}
     </ul>
   </div>
+{%- endif %}
 </div>
 {%- endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,8 +217,8 @@ def zip_fp(db):
     fp = BytesIO()
 
     zipf = ZipFile(fp, 'w')
-    zipf.writestr('Example.txt', 'This is an example')
-    zipf.writestr('Lé UTF8 test.txt', 'This is an example')
+    zipf.writestr('Example.txt', 'This is an example'.encode('utf-8'))
+    zipf.writestr(u'Lé UTF8 test.txt', 'This is an example'.encode('utf-8'))
     zipf.close()
 
     fp.seek(0)

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
+import pytest
 from flask import render_template_string, url_for
 from invenio_db import db
 from invenio_files_rest.models import ObjectVersion
@@ -87,10 +88,8 @@ def test_pdf_extension(app, webassets, bucket, record):
 
 
 def test_csv_dthreejs_extension(app, webassets, bucket, record):
-    """Test view with pdf files."""
-    create_file(
-        record, bucket, 'test.csv', BytesIO(b'A,B\n1,2'))
-
+    """Test view with csv files."""
+    create_file(record, bucket, 'test.csv', BytesIO(b'A,B\n1,2'))
     with app.test_client() as client:
         res = client.get(preview_url(record['control_number'], 'test.csv'))
         assert 'data-csv-source="' in res.get_data(as_text=True)

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -26,7 +26,6 @@
 
 from __future__ import absolute_import, print_function
 
-import pytest
 from flask import render_template_string, url_for
 from invenio_db import db
 from invenio_files_rest.models import ObjectVersion
@@ -96,7 +95,7 @@ def test_csv_dthreejs_extension(app, webassets, bucket, record):
 
 
 def test_zip_extension(app, webassets, bucket, record, zip_fp):
-    """Test view with pdf files."""
+    """Test view with a zip file."""
     create_file(
         record, bucket, 'test.zip', zip_fp)
 
@@ -104,6 +103,16 @@ def test_zip_extension(app, webassets, bucket, record, zip_fp):
         res = client.get(preview_url(record['control_number'], 'test.zip'))
         assert 'Example.txt' in res.get_data(as_text=True)
         assert u'Lé UTF8 test.txt' in res.get_data(as_text=True)
+
+
+def test_invalid_zip(app, webassets, bucket, record):
+    """Test view with an invalid zipfile."""
+    create_file(
+        record, bucket, 'test.zip', BytesIO(b'not a zipfile'))
+
+    with app.test_client() as client:
+        res = client.get(preview_url(record['control_number'], 'test.zip'))
+        assert 'Zipfile is not previewable' in res.get_data(as_text=True)
 
 
 def test_json_extension(app, webassets, bucket, record):


### PR DESCRIPTION
* BETTER Handle a wider variety files than what Python's csv module
  can support (e.g. unsupported Unicode characters and encodings).

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>