### PR TITLE
csv: delimiter passing

### DIFF
--- a/invenio_previewer/extensions/csv_dthreejs.py
+++ b/invenio_previewer/extensions/csv_dthreejs.py
@@ -46,7 +46,7 @@ def validate_csv(file):
     try:
         # Detect encoding and dialect
         encoding = chardet.detect(sample).get('encoding')
-        delimiter = csv.Sniffer().sniff(sample.decode(encoding))
+        delimiter = csv.Sniffer().sniff(sample.decode(encoding)).delimiter
         is_valid = True
     except Exception as e:
         current_app.logger.debug(

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -92,6 +92,16 @@ def test_csv_dthreejs_extension(app, webassets, bucket, record):
     with app.test_client() as client:
         res = client.get(preview_url(record['control_number'], 'test.csv'))
         assert 'data-csv-source="' in res.get_data(as_text=True)
+        assert 'data-csv-delimiter=","' in res.get_data(as_text=True)
+
+
+def test_csv_dthreejs_delimiter(app, webassets, bucket, record):
+    """Test view with csv files."""
+    create_file(record, bucket, 'test.csv', BytesIO(b'A#B\n1#2'))
+    with app.test_client() as client:
+        res = client.get(preview_url(record['control_number'], 'test.csv'))
+        assert 'data-csv-source="' in res.get_data(as_text=True)
+        assert 'data-csv-delimiter="#"' in res.get_data(as_text=True)
 
 
 def test_zip_extension(app, webassets, bucket, record, zip_fp):


### PR DESCRIPTION
* FIX Properly passes CSV delimiter to the previewer template.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>