### PR TITLE
replace mistune markdown previewer with Showdown

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,7 +64,7 @@ JSON (prism.js)
 Markdown
 ~~~~~~~~
 
-.. automodule:: invenio_previewer.extensions.mistune
+.. automodule:: invenio_previewer.extensions.showdown
    :members:
    :undoc-members:
 

--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -31,7 +31,7 @@ module comes with viewers for the following files types:
 - PDF (using PDF.js)
 - ZIP
 - CSV (using d3.js)
-- Markdown (using Mistune library)
+- Markdown (using Showdown library)
 - XML and JSON (using Prism.js)
 - Simple images (PNG, JPG, GIF)
 
@@ -189,7 +189,7 @@ Bundled previewers
 ------------------
 This module contains several previewers out-of-the-box:
 
-- ``Markdown``: Previews a markdown file. It is based on python `mistune`
+- ``Markdown``: Previews a markdown file. It is based on JavaScript `Showdown`
   library.
 
 - ``JSON/XML``: Previews JSON and XML files. It pretty-prints the contents
@@ -285,7 +285,7 @@ is going to be perfect in the case of this TXT previewer:
 >>>         'invenio_previewer.extensions.json_prismjs',
 >>>         'invenio_previewer.extensions.xml_prismjs',
 >>>         'invenio_previewer.extensions.simple_image',
->>>         'invenio_previewer.extensions.mistune',
+>>>         'invenio_previewer.extensions.showdown',
 >>>         'invenio_previewer.extensions.pdfjs',
 >>>         'invenio_previewer.extensions.zip',
 >>>         'invenio_previewer.extensions.default',

--- a/invenio_previewer/bundles.py
+++ b/invenio_previewer/bundles.py
@@ -120,3 +120,14 @@ prism_css = Bundle(
     output='gen/prism.%(version)s.css'
 )
 """CSS bundle for prism.js syntax highlighter."""
+
+showdown_js = Bundle(
+    NpmBundle(
+        npm={
+            "showdown": "1.6.4"
+        },
+    ),
+    "node_modules/showdown/dist/showdown.min.js",
+    "js/showdown/showdown.js",
+    output='gen/prism.%(version)s.js'
+)

--- a/invenio_previewer/config.py
+++ b/invenio_previewer/config.py
@@ -47,7 +47,7 @@ PREVIEWER_PREFERENCE = [
     'simple_image',
     'json_prismjs',
     'xml_prismjs',
-    'mistune',
+    'showdown',
     'pdfjs',
     'ipynb',
     'zip',

--- a/invenio_previewer/extensions/showdown.py
+++ b/invenio_previewer/extensions/showdown.py
@@ -22,32 +22,28 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Markdown rendering using mistune library."""
+"""Markdown previewer based on Showdown."""
 
 from __future__ import absolute_import, unicode_literals
 
-import mistune
 from flask import render_template
-from ..utils import detect_encoding
+
+from ..proxies import current_previewer
 
 previewable_extensions = ['md']
 
 
-def render(file):
-    """Render HTML from Markdown file content."""
-    with file.open() as fp:
-        encoding = detect_encoding(fp, default='utf-8')
-        result = mistune.markdown(fp.read().decode(encoding))
-        return result
-
-
 def can_preview(file):
     """Determine if file can be previewed."""
-    return file.is_local() and file.has_extensions('.md')
+    return file.has_extensions('.md')
 
 
 def preview(file):
-    """Render Markdown."""
-    return render_template("invenio_previewer/mistune.html",
-                           file=file,
-                           content=render(file))
+    """Preview file."""
+    return render_template(
+        'invenio_previewer/showdown.html',
+        file=file,
+        js_bundles=[
+            'previewer_showdown_js'
+        ] + current_previewer.js_bundles,
+    )

--- a/invenio_previewer/static/js/showdown/showdown.js
+++ b/invenio_previewer/static/js/showdown/showdown.js
@@ -1,0 +1,32 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Michaël Zasso
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use strict';
+
+var element = $('#showdown');
+var uri = element.attr('data-markdown-source');
+$.get(uri, function (text) {
+  var converter = new showdown.Converter();
+  var html = converter.makeHtml(text);
+  element.html(html);
+});

--- a/invenio_previewer/templates/invenio_previewer/showdown.html
+++ b/invenio_previewer/templates/invenio_previewer/showdown.html
@@ -28,9 +28,7 @@
 {% block panel %}
 <div class="container">
     <div class="row">
-        <div class="col-md-12">
-            {{content|safe}}
-        </div>
+        <div class="col-md-12" id="showdown" data-markdown-source="{{ file.uri }}"></div>
     </div>
 </div>
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup_requires = [
 install_requires = [
     'Flask>=0.11.1',
     'Flask-BabelEx>=0.9.3',
-    'mistune>=0.7.2',
     'cchardet>=1.0.0',
     'invenio-assets>=1.0.0b4',
     'invenio-pidstore>=1.0.0b1',
@@ -125,7 +124,7 @@ setup(
             'json_prismjs = invenio_previewer.extensions.json_prismjs',
             'simple_image = invenio_previewer.extensions.simple_image',
             'xml_prismjs = invenio_previewer.extensions.xml_prismjs',
-            'mistune = invenio_previewer.extensions.mistune',
+            'showdown = invenio_previewer.extensions.showdown',
             'pdfjs = invenio_previewer.extensions.pdfjs',
             'zip = invenio_previewer.extensions.zip',
             'ipynb = invenio_previewer.extensions.ipynb',


### PR DESCRIPTION
Refs: https://github.com/inveniosoftware/invenio-previewer/issues/61

I don't know if this actually works (waiting on https://github.com/inveniosoftware/invenio-previewer/issues/67 to run the example app) but I'm opening this to gather feedback on the implementation.