### PR TITLE
dependencies: fix breaking change in nbconvert by capping it

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,11 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2019 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
 addopts = --pep8 --ignore=docs --cov=invenio_previewer --cov-report=term-missing
+filterwarnings = ignore::pytest.PytestDeprecationWarning

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,15 +1,17 @@
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2019 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 
 pydocstyle invenio_previewer && \
-isort -rc -c -df **/*.py && \
+isort invenio_previewer tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
+pytest && \
 sphinx-build -qnNW -b doctest docs docs/_build/doctest

--- a/setup.py
+++ b/setup.py
@@ -17,17 +17,11 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'check-manifest>=0.25',
-    'coverage>=4.5.3',
     'invenio-config>=1.0.2',
     'invenio-theme>=1.3.0a10',
     'invenio-db[versioning]>=1.0.2',
-    'isort>=4.3.4',
     'mock>=1.3.0',
-    'pydocstyle>=1.0.0',
-    'pytest-cov>=2.7.1',
-    'pytest-pep8>=1.0.6',
-    'pytest>=4.6.4,<5.0.0',
+    'pytest-invenio>=1.3.2',
 ]
 
 extras_require = {
@@ -60,7 +54,8 @@ install_requires = [
     'invenio-records-ui>=1.1.0',
     'ipython>=4.1.0',
     'mistune>=0.7.2',
-    'nbconvert[execute]>=4.1.0',
+    # NOTE: nbclient package provides execute in nbconvert >= 6.X
+    'nbconvert[execute]>=4.1.0,<6.0.0',
     'nbformat>=4.0.1',
     'tornado>=4.1,<=5.1.1',  # required by nbconvert -> jupyter-client
 ]


### PR DESCRIPTION
nbconvert 6.0 was recently released and it has breaking changes. This is a quick fix that caps the nbconvert dependency. Note that 6.1 plans on dropping support for python 3.6, so there are a couple considerations for future range of dependency support choices. 

Also fixed the isort stuff in passing. The boy-scout rule and all that.