### PR TITLE
Move PDF opening script from inline to a separate file

### DIFF
--- a/invenio_previewer/assets/bootstrap3/js/invenio_previewer/open_pdf.js
+++ b/invenio_previewer/assets/bootstrap3/js/invenio_previewer/open_pdf.js
@@ -1,0 +1,10 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2022 TU Wien.
+//
+// Invenio Theme TUW is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+document.addEventListener("DOMContentLoaded", function () {
+  var fileUri = document.getElementById("pdf-file-uri").value;
+  window.PDFView.open(fileUri);
+});

--- a/invenio_previewer/assets/semantic-ui/js/invenio_previewer/open_pdf.js
+++ b/invenio_previewer/assets/semantic-ui/js/invenio_previewer/open_pdf.js
@@ -1,0 +1,10 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2022 TU Wien.
+//
+// Invenio Theme TUW is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+document.addEventListener("DOMContentLoaded", function () {
+  var fileUri = document.getElementById("pdf-file-uri").value;
+  window.PDFView.open(fileUri);
+});

--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2019 CERN.
+  Copyright (C)      2022 TU Wien.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,7 @@
 {%- extends config.PREVIEWER_BASE_TEMPLATE %}
 
 {%- block html_tags %}
-  {{ html_tags }}
+  {{ html_tags|safe }}
 {%- endblock %}
 
 {%- block head %}

--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -45,6 +45,7 @@
 
     <div id="mainContainer">
       <div class="findbar hidden doorHanger hiddenSmallView" id="findbar">
+        <input id="pdf-file-uri" type="hidden" value="{{ file.uri }}" />
         <label for="findInput" class="toolbarLabel" data-l10n-id="find_label">{{_('Find:')}}</label>
         <input id="findInput" class="toolbarField" tabindex="41">
         <div class="splitToolbarButton">
@@ -309,7 +310,5 @@
 
 {%- block javascript %}
   {{ super() }}
-  <script>
-    PDFView.open('{{ file.uri }}');
-  </script>
+  {{ webpack['open_pdf.js'] }}
 {%- endblock %}

--- a/invenio_previewer/templates/semantic-ui/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/semantic-ui/invenio_previewer/pdfjs.html
@@ -45,6 +45,7 @@
 
     <div id="mainContainer">
       <div class="findbar hidden doorHanger hiddenSmallView" id="findbar">
+        <input id="pdf-file-uri" type="hidden" value="{{ file.uri }}" />
         <label for="findInput" class="toolbarLabel" data-l10n-id="find_label">{{_('Find:')}}</label>
         <input id="findInput" class="toolbarField" tabindex="41">
         <div class="splitToolbarButton">
@@ -309,7 +310,5 @@
 
 {%- block javascript %}
   {{ super() }}
-  <script>
-    PDFView.open('{{ file.uri }}');
-  </script>
+  {{ webpack['open_pdf.js'] }}
 {%- endblock %}

--- a/invenio_previewer/templates/semantic-ui/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/semantic-ui/invenio_previewer/pdfjs.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2020 CERN.
+  Copyright (C)      2022 TU Wien.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,7 @@
 {%- extends config.PREVIEWER_BASE_TEMPLATE %}
 
 {%- block html_tags %}
-  {{ html_tags }}
+  {{ html_tags|safe }}
 {%- endblock %}
 
 {%- block head %}

--- a/invenio_previewer/webpack.py
+++ b/invenio_previewer/webpack.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016-2022 CERN.
+# Copyright (C)      2022 TU Wien.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -42,6 +43,7 @@ previewer = WebpackThemeBundle(
                 'prism_css': './scss/invenio_previewer/prismjs.scss',
                 'pdfjs_js': './js/invenio_previewer/pdfjs.js',
                 'pdfjs_css': './scss/invenio_previewer/pdfjs.scss',
+                'open_pdf': './js/invenio_previewer/open_pdf.js',
                 'simple_image_css':
                     './scss/invenio_previewer/simple_image.scss',
             },
@@ -66,6 +68,7 @@ previewer = WebpackThemeBundle(
                 'prism_js': './js/invenio_previewer/prismjs.js',
                 'prism_css': './scss/invenio_previewer/prismjs.scss',
                 'pdfjs_js': './js/invenio_previewer/pdfjs.js',
+                'open_pdf': './js/invenio_previewer/open_pdf.js',
                 'bottom_js': './js/invenio_previewer/bottom.js',
                 'pdfjs_css': './scss/invenio_previewer/pdfjs.scss',
                 'zip_css': './scss/invenio_previewer/zip.scss',


### PR DESCRIPTION
As is, the JS used for opening the PDF file preview is an inline script.
This will break if the admin sets a stricter CSP header for `script-src` (by disallowing the `unsafe-inline` source).
Moving said script into a separate file allows a stricter CSP configuration, such as we are currently running:

```python
APP_DEFAULT_SECURE_HEADERS = {
    "content_security_policy": {
        "default-src": [
            "'self'",
            "data:",  # fonts
            "blob:",  # for pdf preview
            "*.tuwien.ac.at",  # matomo
            "*.tuwien.at",  # matomo
        ],
        "style-src": [
            "'self'",
            "'unsafe-inline'",  # allow inline styles for CK Editor
        ],
    },
    "content_security_policy_nonce_in": ["default-src", "script-src"],
    "content_security_policy_report_only": False,
    "content_security_policy_report_uri": None,
    "force_file_save": False,
    "force_https": True,
    "force_https_permanent": False,
    "frame_options": "sameorigin",
    "frame_options_allow_from": None,
    "session_cookie_http_only": True,
    "session_cookie_secure": True,
    "strict_transport_security": True,
    "strict_transport_security_include_subdomains": True,
    "strict_transport_security_max_age": 31556926,  # One year in seconds
    "strict_transport_security_preload": False,
}
```

Side note: The `nonce` value is used in [our customized landing page](https://gitlab.tuwien.ac.at/fairdata/invenio-theme-tuw/-/blob/master/invenio_theme_tuw/theme/templates/semantic-ui/invenio_app_rdm/records/detail.html#L37) for the schema.org JSON-LD metadata:
```django
{%- block tuw_metadata -%}
  {#- this is where the schema.org metadata (as fetched from datacite) is inserted, for google datasets #}
  {%- set schemaorg_metadata = tuw_create_schemaorg_metadata(record) %}

  {%- if schemaorg_metadata %}
    <script type="application/ld+json" nonce="{{ csp_nonce() }}">
      {{ schemaorg_metadata|safe }}
    </script>
  {%- endif %}
{%- endblock tuw_metadata %}
```