### PR TITLE
[BLOCKED] Replace `cchardet` with `faust-cchardet`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    cchardet>=1.0.0
+    faust-cchardet>=1.0.0
     invenio-assets>=1.2.7
     invenio-base>=1.2.10
     invenio-formatter>=1.1.3


### PR DESCRIPTION
* the original package hasn't received updates since 2021, while the latter is still active
* cchardet also doesn't play nice with python 3.10 and 3.11