### PR TITLE
add lxml_html_clean now that it's broken off lxml

### DIFF
--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -318,6 +318,6 @@ Now define the priority for all previewers by adding the newly created
 from .ext import InvenioPreviewer
 from .proxies import current_previewer
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 __all__ = ("__version__", "current_previewer", "InvenioPreviewer")

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     mistune>=0.8.1
     nbconvert>=7,<8
     nbformat>=5.1,<6.0
+    lxml-html-clean>=0.1.1
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
[lxml 5.2 took out](https://github.com/lxml/lxml/blob/master/CHANGES.txt#L45) into a separate distribution package ([lxml-html-clean](https://pypi.org/project/lxml-html-clean/)) code related to html cleaning. This caused `nbconvert` imports to break and so `invenio_previewer/extensions/ipynb.py` to break which then masked the error for subsequent preview calls.

I am placing the dependency on `lxml_html_clean` here since this is the trigger for the import problem. A backport should be done to maint-1.3 via cherry-pick when this is merged. (I can't merge on this repo, so backport better done by merger).

The solution for individual instances for now is to add `lxml_html_clean` to their Pipfile.  
   
