### PR TITLE
fix: ModuleWarning: Deprecation Warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 ..
     This file is part of Invenio.
     Copyright (C) 2016-2024 CERN.
-    Copyright (C) 2024 Graz University of Technology.
+    Copyright (C) 2024-2025 Graz University of Technology.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
@@ -10,6 +10,9 @@
 Changes
 =======
 
+Version unreleased
+
+- fix: ModuleWarning: Deprecation Warning
 
 Version 3.0.0 (release 2024-12-10)
 

--- a/invenio_previewer/assets/semantic-ui/scss/invenio_previewer/prismjs.scss
+++ b/invenio_previewer/assets/semantic-ui/scss/invenio_previewer/prismjs.scss
@@ -6,7 +6,7 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-@import "~prismjs/themes/prism";
+@use "~prismjs/themes/prism";
 
 code[class*="language-"], pre[class*="language-"] {
   line-height: 1.0;


### PR DESCRIPTION
* Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
  More info and automated migrator: https://sass-lang.com/d/import
