### PR TITLE
Disable sandboxed JS execution in PDF.js and open links in new tabs

### DIFF
--- a/invenio_previewer/config.py
+++ b/invenio_previewer/config.py
@@ -35,6 +35,9 @@ PREVIEWER_CSV_MAX_BYTES = 100 * 1024 * 1024
 PREVIEWER_ZIP_MAX_FILES = 1000
 """Max number of files showed in the ZIP previewer."""
 
+PREVIEWER_PDF_JS_ENABLE_SCRIPTING = False
+"""Enable JavaScript execution in PDF files (disabled by default for security)."""
+
 PREVIEWER_PREFERENCE = [
     "csv_papaparsejs",
     "simple_image",

--- a/invenio_previewer/static/js/open_pdf.js
+++ b/invenio_previewer/static/js/open_pdf.js
@@ -29,7 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Get the PDF file's URL
   const PDF_URL = document.getElementById("pdf-file-uri").value;
   const ENABLE_XFA = true;
-  
+
   // Get scripting configuration from DOM (defaults to false for security)
   const enableScriptingElement = document.getElementById("pdf-enable-scripting");
   const ENABLE_SCRIPTING = enableScriptingElement ? enableScriptingElement.value === "true" : false;
@@ -49,6 +49,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // (Optionally) enable hyperlinks within PDF files
   const pdfLinkService = new pdfjsViewer.PDFLinkService({
     eventBus,
+    externalLinkTarget: pdfjsViewer.LinkTarget.BLANK,
   });
 
   // (Optionally) enable find controller
@@ -65,7 +66,7 @@ document.addEventListener("DOMContentLoaded", () => {
     linkService: pdfLinkService,
     findController: pdfFindController,
   };
-  
+
   if (ENABLE_SCRIPTING) {
     pdfScriptingManager = new pdfjsViewer.PDFScriptingManager({
       eventBus,
@@ -76,7 +77,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const pdfViewer = new pdfjsViewer.PDFViewer(pdfViewerOptions);
   pdfLinkService.setViewer(pdfViewer);
-  
+
   if (pdfScriptingManager) {
     pdfScriptingManager.setViewer(pdfViewer);
   }

--- a/invenio_previewer/static/js/open_pdf.js
+++ b/invenio_previewer/static/js/open_pdf.js
@@ -29,7 +29,10 @@ document.addEventListener("DOMContentLoaded", () => {
   // Get the PDF file's URL
   const PDF_URL = document.getElementById("pdf-file-uri").value;
   const ENABLE_XFA = true;
-
+  
+  // Get scripting configuration from DOM (defaults to false for security)
+  const enableScriptingElement = document.getElementById("pdf-enable-scripting");
+  const ENABLE_SCRIPTING = enableScriptingElement ? enableScriptingElement.value === "true" : false;
   const SANDBOX_BUNDLE_SRC = "/static/js/pdfjs/build/pdf.sandbox.min.mjs";
 
   const container = document.getElementById("viewerContainer");
@@ -54,21 +57,29 @@ document.addEventListener("DOMContentLoaded", () => {
     linkService: pdfLinkService,
   });
 
-  // (Optionally) enable scripting support
-  const pdfScriptingManager = new pdfjsViewer.PDFScriptingManager({
-    eventBus,
-    sandboxBundleSrc: SANDBOX_BUNDLE_SRC,
-  });
-
-  const pdfViewer = new pdfjsViewer.PDFViewer({
+  // Conditionally create scripting manager based on configuration
+  let pdfScriptingManager = null;
+  let pdfViewerOptions = {
     container,
     eventBus,
     linkService: pdfLinkService,
     findController: pdfFindController,
-    scriptingManager: pdfScriptingManager,
-  });
+  };
+  
+  if (ENABLE_SCRIPTING) {
+    pdfScriptingManager = new pdfjsViewer.PDFScriptingManager({
+      eventBus,
+      sandboxBundleSrc: SANDBOX_BUNDLE_SRC,
+    });
+    pdfViewerOptions.scriptingManager = pdfScriptingManager;
+  }
+
+  const pdfViewer = new pdfjsViewer.PDFViewer(pdfViewerOptions);
   pdfLinkService.setViewer(pdfViewer);
-  pdfScriptingManager.setViewer(pdfViewer);
+  
+  if (pdfScriptingManager) {
+    pdfScriptingManager.setViewer(pdfViewer);
+  }
 
   // Register event handlers for controls
   nextPageButton.addEventListener("click", function() {

--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -28,6 +28,7 @@
 
 {%- block page_body %}
 <input id="pdf-file-uri" type="hidden" value="{{ file.uri }}" />
+<input id="pdf-enable-scripting" type="hidden" value="{{ config.PREVIEWER_PDF_JS_ENABLE_SCRIPTING|default(false)|lower }}" />
 
   <div id="outerContainer">
       <div id="mainContainer">


### PR DESCRIPTION
Closes #230.

We don't have E2E tests unfortunately, ~~so I'll have to go through all the previewers and see if they're still working as expected (which is why I opened this as a draft). I've tested all the previewers and they all work (on my machine at least 😅).~~ See [comment below](https://github.com/inveniosoftware/invenio-previewer/pull/231#issuecomment-3214679574)

- **feat(pdfjs): open links in new tabs**
  * Sets by default in the PDF.js settings that links open in a new tab.
    The old behaviort was that when clicking a link inside a previewed
    PDF, the navigation happens inside the iframe, which then because of
    the `X-Frame-Options: sameorigin` setting blocked the content.
- **feat(pdfjs): disable sandboxed JS execution by default**
  * Adds a new `PREVIEWER_PDF_JS_ENABLE_SCRIPTING` config variable for
    allowing to disable the sandboxed JS execution support in PDF.js.
    This config is by default set to `False`.