### PR TITLE
fix(ext): avoid unecessary assert error

### DIFF
--- a/invenio_previewer/ext.py
+++ b/invenio_previewer/ext.py
@@ -9,7 +9,6 @@
 
 """Invenio module for previewing files."""
 
-
 from flask import current_app
 from invenio_base.utils import entry_points
 from werkzeug.utils import cached_property, import_string
@@ -80,9 +79,14 @@ class _InvenioPreviewerState(object):
     def register_previewer(self, name, previewer):
         """Register a previewer in the system."""
         if name in self.previewers:
-            assert (
-                name not in self.previewers
-            ), "Previewer with same name already registered"
+            if self.previewers[name] is previewer:
+                return
+            else:
+                raise RuntimeError(
+                    f"Previewer '{name}' is already registered with instance "
+                    f"{self.previewers[name]!r}, cannot register different instance "
+                    f"{previewer!r}."
+                )
         self.previewers[name] = previewer
         if hasattr(previewer, "previewable_extensions"):
             self._previewable_extensions |= set(previewer.previewable_extensions)

--- a/invenio_previewer/extensions/mistune.py
+++ b/invenio_previewer/extensions/mistune.py
@@ -8,7 +8,6 @@
 
 """Markdown rendering using mistune library."""
 
-import bleach
 import mistune
 from flask import current_app, render_template
 


### PR DESCRIPTION
* The check for an already registered previewer was just checking by
  name, instead of also verifying if the registered object is the same
  instance.
* Instead of an assertion, we raise a `RuntimeError` with information
  about the already registered and conflicting previewer instances.
