### PR TITLE
file-list: show fallback message if file checksum is not available

### DIFF
--- a/invenio_previewer/templates/invenio_previewer/macros.html
+++ b/invenio_previewer/templates/invenio_previewer/macros.html
@@ -36,7 +36,7 @@
           {%- else %}
             <a class="forcewrap" href="{{ file_url_download }}">{{ file.key }}</a>
           {%- endif %}
-          <br/><small class="text-muted nowrap">{{file.checksum}} <i class="fa fa-question-circle text-muted" data-toggle="tooltip" tooltip data-placement="top" title="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}"></i></small>
+          <br/><small class="text-muted nowrap">{{ file.checksum or _("Checksum not yet calculated.") }} <i class="fa fa-question-circle text-muted" data-toggle="tooltip" tooltip data-placement="top" title="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}"></i></small>
         </td>
         <td class="nowrap">{{ file.size|filesizeformat }}</td>
         <td class="nowrap">

--- a/invenio_previewer/templates/semantic-ui/invenio_previewer/macros.html
+++ b/invenio_previewer/templates/semantic-ui/invenio_previewer/macros.html
@@ -33,7 +33,7 @@
       <tr>
         <td>
           <a href="{{ file_url_download }}">{{ file.key }}</a>
-          <br/><small>{{file.checksum}} 
+          <br/><small>{{ file.checksum or _("Checksum not yet calculated.") }}
             <div class="ui icon inline-block" data-tooltip="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}">
               <i class="question circle checksum icon"></i>
             </div>


### PR DESCRIPTION
This shows a fallback message if the file's checksum is not yet available, which can be happen if the checksum is calculated asynchronously (e.g. multipart file upload with local file storage).

See also https://github.com/inveniosoftware/invenio-records-resources/pull/650