### PR TITLE
fix(pdfjs): specify Wasm URL parameter for OpenJPEG decoding

### DIFF
--- a/invenio_previewer/static/js/open_pdf.js
+++ b/invenio_previewer/static/js/open_pdf.js
@@ -26,6 +26,9 @@ document.addEventListener("DOMContentLoaded", () => {
   const CMAP_URL = "/static/js/pdfjs/cmaps/";
   const CMAP_PACKED = true;
 
+  // Some PDFs with JPEG 2000 images need the external OpenJPEG Wasm module
+  const WASM_URL = "/static/js/pdfjs/wasm/";
+
   // Get the PDF file's URL
   const PDF_URL = document.getElementById("pdf-file-uri").value;
   const ENABLE_XFA = true;
@@ -144,6 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
     url: PDF_URL,
     cMapUrl: CMAP_URL,
     cMapPacked: CMAP_PACKED,
+    wasmUrl: WASM_URL,
     enableXfa: ENABLE_XFA,
   });
   (async function () {

--- a/invenio_previewer/webpack.py
+++ b/invenio_previewer/webpack.py
@@ -67,6 +67,10 @@ previewer = WebpackThemeBundle(
                     "to": "../../static/js/pdfjs/cmaps",
                 },
                 {
+                    "from": "../node_modules/pdfjs-dist/wasm",
+                    "to": "../../static/js/pdfjs/wasm",
+                },
+                {
                     "from": "../node_modules/pdfjs-dist/web",
                     "to": "../../static/js/pdfjs/web",
                 },
@@ -112,6 +116,10 @@ previewer = WebpackThemeBundle(
                 {
                     "from": "../node_modules/pdfjs-dist/cmaps",
                     "to": "../../static/js/pdfjs/cmaps",
+                },
+                {
+                    "from": "../node_modules/pdfjs-dist/wasm",
+                    "to": "../../static/js/pdfjs/wasm",
                 },
                 {
                     "from": "../node_modules/pdfjs-dist/web",


### PR DESCRIPTION
Fixes #239
Tested with Zenodo locally. The OpenJPEG Wasm file is downloaded just a bit before the page requiring it, and the image is displayed correctly.