### PR TITLE
feat: Extend support for container item previewers.

### DIFF
--- a/invenio_previewer/ext.py
+++ b/invenio_previewer/ext.py
@@ -42,13 +42,36 @@ class _InvenioPreviewerState(object):
         self.entry_point_group = entry_point_group
         self.previewers = {}
         self._previewable_extensions = set()
+        self._container_item_previewable_extensions = set()
 
     @cached_property
     def previewable_extensions(self):
+        """Return previewable extensions for files."""
         if self.entry_point_group is not None:
             self.load_entry_point_group(self.entry_point_group)
             self.entry_point_group = None
         return self._previewable_extensions
+
+    @cached_property
+    def container_item_previewable_extensions(self):
+        """Return previewable extensions for container items."""
+        if self.entry_point_group is not None:
+            self.load_entry_point_group(self.entry_point_group)
+            self.entry_point_group = None
+        return self._container_item_previewable_extensions
+
+    @cached_property
+    def previewer_preference(self):
+        """Get previewer preference from config."""
+        return self.app.config.get("PREVIEWER_PREFERENCE", [])
+
+    @cached_property
+    def previewer_container_item_preference(self):
+        """Get container previewer preference from config."""
+        return (
+            self.app.config.get("PREVIEWER_CONTAINER_ITEM_PREFERENCE", [])
+            or self.previewer_preference
+        )
 
     @cached_property
     def record_file_factory(self):
@@ -89,7 +112,13 @@ class _InvenioPreviewerState(object):
                 )
         self.previewers[name] = previewer
         if hasattr(previewer, "previewable_extensions"):
-            self._previewable_extensions |= set(previewer.previewable_extensions)
+            # Add the extension only if the previewer is in the preference list (it is enabled).
+            if name in self.previewer_preference:
+                self._previewable_extensions |= set(previewer.previewable_extensions)
+            if name in self.previewer_container_item_preference:
+                self._container_item_previewable_extensions |= set(
+                    previewer.previewable_extensions
+                )
 
     def load_entry_point_group(self, entry_point_group):
         """Load previewers from an entry point group."""
@@ -102,11 +131,17 @@ class _InvenioPreviewerState(object):
             self.load_entry_point_group(self.entry_point_group)
             self.entry_point_group = None
 
-        previewers = previewers or self.app.config.get("PREVIEWER_PREFERENCE", [])
+        previewers = previewers or self.previewer_preference
 
         for item in previewers:
             if item in self.previewers:
                 yield self.previewers[item]
+
+    def iter_container_item_previewers(self, previewers=None):
+        """Get previewers ordered by PREVIEWER_CONTAINER_ITEM_PREFERENCE."""
+        return self.iter_previewers(
+            previewers=previewers or self.previewer_container_item_preference
+        )
 
 
 class InvenioPreviewer(object):

--- a/invenio_previewer/views.py
+++ b/invenio_previewer/views.py
@@ -77,3 +77,9 @@ def preview(pid, record, template=None, **kwargs):
 def is_previewable(extension):
     """Test if a file can be previewed checking its extension."""
     return extension in current_previewer.previewable_extensions
+
+
+@blueprint.app_template_test("container_item_previewable")
+def is_container_item_previewable(extension):
+    """Decide if a container item (file inside zip) is previewable."""
+    return extension in current_previewer.container_item_previewable_extensions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@
 
 """Pytest configuration."""
 
+import contextlib
 import os
 import shutil
 import tempfile
@@ -62,6 +63,7 @@ def app_config(app_config):
             ),
         ),
         SERVER_NAME="localhost",
+        CONTAINER_ITEM_PREVIEWER_PREFERENCE=["pdfjs", "zipfile"],
     )
     return app_config
 
@@ -194,3 +196,22 @@ def zip_fp(db):
 
     fp.seek(0)
     return fp
+
+
+@pytest.fixture(autouse=True)
+def clear_previewer_preference_cache(testapp):
+    """Clear cached previewer preferences.
+
+    Since we changed properties to cached_property,
+    the values must be cleared between tests as they change the configuration in some tests.
+    """
+    with contextlib.suppress(KeyError):
+        del testapp.extensions["invenio-previewer"].previewable_extensions
+    with contextlib.suppress(KeyError):
+        del testapp.extensions[
+            "invenio-previewer"
+        ].container_item_previewable_extensions
+    with contextlib.suppress(KeyError):
+        del testapp.extensions["invenio-previewer"].previewer_preference
+    with contextlib.suppress(KeyError):
+        del testapp.extensions["invenio-previewer"].container_item_previewer_preference

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@
 
 """Pytest configuration."""
 
+import contextlib
 import os
 import shutil
 import tempfile
@@ -62,6 +63,7 @@ def app_config(app_config):
             ),
         ),
         SERVER_NAME="localhost",
+        PREVIEWER_CONTAINER_ITEM_PREFERENCE=["pdfjs", "zipfile"],
     )
     return app_config
 
@@ -194,3 +196,22 @@ def zip_fp(db):
 
     fp.seek(0)
     return fp
+
+
+@pytest.fixture(autouse=True)
+def clear_previewer_preference_cache(testapp):
+    """Clear cached previewer preferences.
+
+    Since we changed properties to cached_property,
+    the values must be cleared between tests as they change the configuration in some tests.
+    """
+    with contextlib.suppress(KeyError):
+        del testapp.extensions["invenio-previewer"].previewable_extensions
+    with contextlib.suppress(KeyError):
+        del testapp.extensions[
+            "invenio-previewer"
+        ].container_item_previewable_extensions
+    with contextlib.suppress(KeyError):
+        del testapp.extensions["invenio-previewer"].previewer_preference
+    with contextlib.suppress(KeyError):
+        del testapp.extensions["invenio-previewer"].previewer_container_item_preference

--- a/tests/test_invenio_previewer.py
+++ b/tests/test_invenio_previewer.py
@@ -104,3 +104,67 @@ def test_register_previewer_duplicate():
 
     # Ensure original previewer is still registered
     assert ext.previewers["test"] is previewer1
+
+
+@patch("importlib.metadata.entry_points", lambda group=None: [])
+def test_iter_container_item_previewers():
+    """Test iter_container_previewers with PREVIEWER_CONTAINER_ITEM_PREFERENCE."""
+
+    # Mock previewer modules
+    class MockPreviewer1:
+        previewable_extensions = [".txt"]
+
+    class MockPreviewer2:
+        previewable_extensions = [".pdf"]
+
+    class MockPreviewer3:
+        previewable_extensions = [".zip"]
+
+    previewer1 = MockPreviewer1()
+    previewer2 = MockPreviewer2()
+    previewer3 = MockPreviewer3()
+
+    # Test with PREVIEWER_CONTAINER_ITEM_PREFERENCE set
+    app = Flask("testapp")
+    app.config["PREVIEWER_PREFERENCE"] = ["txt", "pdf", "zip"]
+    app.config["PREVIEWER_CONTAINER_ITEM_PREFERENCE"] = ["zip", "pdf"]
+    ext = InvenioPreviewer(app)
+
+    ext.register_previewer("txt", previewer1)
+    ext.register_previewer("pdf", previewer2)
+    ext.register_previewer("zip", previewer3)
+
+    # Should return previewers in PREVIEWER_CONTAINER_ITEM_PREFERENCE order
+    result = list(ext.iter_container_item_previewers())
+    assert result == [previewer3, previewer2]
+
+    # Test fallback to PREVIEWER_PREFERENCE when PREVIEWER_CONTAINER_ITEM_PREFERENCE not set
+    app2 = Flask("testapp2")
+    app2.config["PREVIEWER_PREFERENCE"] = ["pdf", "txt"]
+    ext2 = InvenioPreviewer(app2)
+
+    ext2.register_previewer("txt", previewer1)
+    ext2.register_previewer("pdf", previewer2)
+    ext2.register_previewer("zip", previewer3)
+
+    # Should fall back to PREVIEWER_PREFERENCE order
+    result2 = list(ext2.iter_container_item_previewers())
+    assert result2 == [previewer2, previewer1]
+
+    # Test with custom previewers parameter
+    result3 = list(ext.iter_container_item_previewers(previewers=["txt", "zip"]))
+    assert result3 == [previewer1, previewer3]
+
+    # Test with empty PREVIEWER_CONTAINER_ITEM_PREFERENCE (should fall back)
+    app3 = Flask("testapp3")
+    app3.config["PREVIEWER_PREFERENCE"] = ["zip"]
+    app3.config["PREVIEWER_CONTAINER_ITEM_PREFERENCE"] = []
+    ext3 = InvenioPreviewer(app3)
+
+    ext3.register_previewer("txt", previewer1)
+    ext3.register_previewer("pdf", previewer2)
+    ext3.register_previewer("zip", previewer3)
+
+    # Empty list is falsy, should fall back to PREVIEWER_PREFERENCE
+    result4 = list(ext3.iter_container_item_previewers())
+    assert result4 == [previewer3]


### PR DESCRIPTION
### Description

This PR is one of the 4 PRs enabling invenio to preview files inside zip archives and other container files in general. 

The other parts are:
* [invenio-records-resources](https://github.com/inveniosoftware/invenio-records-resources/pull/666) which provides the API for listing container and accessing/extracting container items
* [invenio-rdm-records](https://github.com/inveniosoftware/invenio-rdm-records/pull/2222) which provides the concrete implementation of this API for ZIP archives 
* [invenio-app-rdm](https://github.com/inveniosoftware/invenio-app-rdm/pull/3266) enabled support in the UI for previewing/downloading of container items (files/folders) by creating a new independent zip previewer

All these features are opt-in, see RFC for configuration details.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
