### PR TITLE
refactor(pdfjs): Display 'Download' text on button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@
 Changes
 =======
 
+Version v4.1.0 (released 2026-03-03)
+
+- refactor(pdfjs): Display 'Download' text on button
+- feat(pdfjs): open PDF at page from URL hash
+
 Version v4.0.0 (released 2026-02-03)
 
 - chore(black): update formatting to >= 26.0

--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -352,6 +352,6 @@ Now define the priority for all previewers by adding the newly created
 from .ext import InvenioPreviewer
 from .proxies import current_previewer
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 __all__ = ("__version__", "current_previewer", "InvenioPreviewer")

--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -93,8 +93,8 @@
 
               <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
                 <div id="downloadContainer" class="toolbarHorizontalGroup">
-                  <button id="downloadButton" class="toolbarButton presentationMode" title="{{ _("Download PDF file") }}">
-                    <span>{{ _("Download PDF file") }}</span>
+                  <button id="downloadButton" class="toolbarButton presentationMode labeled" title="{{ _("Download PDF file") }}">
+                    <span>{{ _("Download") }}</span>
                   </button>
                 </div>
                 <div id="fullScreenModeContainer" class="toolbarHorizontalGroup">


### PR DESCRIPTION
Some users are not able to easily find the download button just with the icon.

<img width="301" height="161" alt="Screenshot 2026-03-03 at 09 58 34" src="https://github.com/user-attachments/assets/0df72a7c-ae5f-4c83-b5fd-8c7336891245" />