### PR TITLE
fix(pdfjs): switch to legacy bundle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@
 Changes
 =======
 
+Version v4.1.1 (released 2026-03-04)
+
+- fix(pdfjs): switch to legacy bundle
+
 Version v4.1.0 (released 2026-03-03)
 
 - refactor(pdfjs): Display 'Download' text on button

--- a/invenio_previewer/__init__.py
+++ b/invenio_previewer/__init__.py
@@ -352,6 +352,6 @@ Now define the priority for all previewers by adding the newly created
 from .ext import InvenioPreviewer
 from .proxies import current_previewer
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 __all__ = ("__version__", "current_previewer", "InvenioPreviewer")

--- a/invenio_previewer/webpack.py
+++ b/invenio_previewer/webpack.py
@@ -59,7 +59,7 @@ previewer = WebpackThemeBundle(
             copy=[
                 # Copy the pdfjs-dist artifacts from `node_modules` into `static`
                 {
-                    "from": "../node_modules/pdfjs-dist/build",
+                    "from": "../node_modules/pdfjs-dist/legacy/build",
                     "to": "../../static/js/pdfjs/build",
                 },
                 {
@@ -71,7 +71,7 @@ previewer = WebpackThemeBundle(
                     "to": "../../static/js/pdfjs/wasm",
                 },
                 {
-                    "from": "../node_modules/pdfjs-dist/web",
+                    "from": "../node_modules/pdfjs-dist/legacy/web",
                     "to": "../../static/js/pdfjs/web",
                 },
                 {
@@ -110,7 +110,7 @@ previewer = WebpackThemeBundle(
             copy=[
                 # Copy the pdfjs-dist artifacts from `node_modules` into `static`
                 {
-                    "from": "../node_modules/pdfjs-dist/build",
+                    "from": "../node_modules/pdfjs-dist/legacy/build",
                     "to": "../../static/js/pdfjs/build",
                 },
                 {
@@ -122,7 +122,7 @@ previewer = WebpackThemeBundle(
                     "to": "../../static/js/pdfjs/wasm",
                 },
                 {
-                    "from": "../node_modules/pdfjs-dist/web",
+                    "from": "../node_modules/pdfjs-dist/legacy/web",
                     "to": "../../static/js/pdfjs/web",
                 },
                 {


### PR DESCRIPTION
* pdfjs is distributed via a "modern" build which uses unabstracted modern JS features for the smallest bundle size and best performance, and a "legacy" build which polyfills these features leading to slightly worse performance and bigger bundles but support for older browsers. More details:
https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support. The "legacy" build is _not_ older than the "modern" build, both of the bundle types are always released for each new version of pdfjs. So it contains all the same features and the same API, etc. The legacy build also still supports modern browsers.

* We have experienced some errors in older browsers, hence we are switching to the legacy build for better support. This won't significantly impact performance and it won't decrease support for modern browsers.

* The NPM package we are using for pdfjs contains the legacy build under the `legacy` directory:
https://www.npmjs.com/package/pdfjs-dist?activeTab=code
