### PR TITLE
Fix/255 pdfjs highlight offset

### DIFF
--- a/invenio_previewer/templates/invenio_previewer/pdfjs.html
+++ b/invenio_previewer/templates/invenio_previewer/pdfjs.html
@@ -15,7 +15,6 @@
 {%- endblock %}
 
 {%- block head %}
-  {{ super() }}
   <meta name="google" content="notranslate">
   <link rel="resource" type="application/l10n" href="{{ url_for('static', filename='js/pdfjs/web/locale/locale.properties') }}" />
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='js/pdfjs/web/pdf_viewer.css') }}" />


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description


Fixes #255. On InvenioRDM the PDF preview was loading theme.css through super() in the head, which messed up text selection in PDF.js. I removed that so only the PDF viewer styles load, and highlights line up with the text again.

<img width="933" height="779" alt="image" src="https://github.com/user-attachments/assets/a0b517e0-7169-4989-ba3f-890ad224d170" />



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
