### PR TITLE
markdown: enable plugins strikethrough, footnotes, table

### DIFF
--- a/invenio_previewer/extensions/mistune.py
+++ b/invenio_previewer/extensions/mistune.py
@@ -11,12 +11,25 @@ from ..utils import detect_encoding
 
 previewable_extensions = ["md"]
 
+# See: https://mistune.lepture.com/en/latest/guide.html
+# Using the same plugins as the ones enabled by default
+# in the `html()` method.
+# The difference with the `html()` method is that here
+# we are escaping HTML tags present in the Markdown file.
+markdown = mistune.create_markdown(
+    plugins=[
+        "strikethrough",
+        "footnotes",
+        "table",
+    ]
+)
+
 
 def render(file):
     """Render HTML from Markdown file content."""
     with file.open() as fp:
         encoding = detect_encoding(fp, default="utf-8")
-        return mistune.markdown(fp.read().decode(encoding))
+        return markdown(fp.read().decode(encoding))
 
 
 def can_preview(file):

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -53,11 +53,23 @@ def test_default_extension(testapp, webassets, record):
 
 def test_markdown_extension(testapp, webassets, record):
     """Test view with md files."""
-    create_file(record, "markdown.md", BytesIO(b"### Testing markdown ###"))
+    bytes_file = b"""
+### Testing markdown ###
+
+<div>Inline HTML tag</div>
+
+| header1 | header2 |
+| ------- | ------- |
+| data1   | data2   |
+"""
+    create_file(record, "markdown.md", BytesIO(bytes_file))
     with testapp.test_client() as client:
         res = client.get(preview_url(record["control_number"], "markdown.md"))
-        assert "<h3>Testing markdown" in res.get_data(as_text=True)
-        with patch("mistune.markdown", side_effect=Exception):
+        as_text = res.get_data(as_text=True)
+        assert "<h3>Testing markdown" in as_text
+        assert "&lt;div&gt;Inline HTML tag" in as_text
+        assert "<td>data1" in as_text
+        with patch("mistune.Markdown.__call__", side_effect=Exception):
             res = client.get(preview_url(record["control_number"], "markdown.md"))
             assert "we are unfortunately not" in res.get_data(as_text=True)
 


### PR DESCRIPTION
Even though tables are an extension of Markdown, this is pretty common and people expect support for it.

This pull requests enables the "table" plugin, as well as the "strikethrough" and "footnotes" plugins (which are included by default in other places in the mistune library).